### PR TITLE
The Stubby also requires Visual C++ Redistributable 2019

### DIFF
--- a/stubby.nuspec
+++ b/stubby.nuspec
@@ -33,6 +33,7 @@ increasing end user privacy.
 - For more details on configuring, testing and running stubby after installation see https://dnsprivacy.org/wiki/display/DP/Windows+installer+for+Stubby</description>
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.3.3" />
+      <dependency id="vcredist140" version="14.29.30037" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
More specifically, Stubby for Windows requires `vcruntime140.dll`. Therefore, another workaround is to carry `vcruntime140.dll` in the Stubby installer.